### PR TITLE
Added some casualty milestones to the kill counter for context

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.8)
     execjs (2.6.0)
+    ffi (1.9.10)
     ffi (1.9.10-x64-mingw32)
     ffi (1.9.10-x86-mingw32)
     haml (4.0.7)
@@ -47,6 +48,7 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     kramdown (1.8.0)
+    libv8 (3.16.14.13)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -105,6 +107,7 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    ref (2.0.0)
     sass (3.4.18)
     sprockets (2.12.4)
       hike (~> 1.2)
@@ -116,6 +119,9 @@ GEM
     sprockets-sass (1.3.1)
       sprockets (~> 2.0)
       tilt (~> 1.1)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -132,6 +138,7 @@ GEM
     wdm (0.1.1)
 
 PLATFORMS
+  ruby
   x64-mingw32
   x86-mingw32
 
@@ -146,4 +153,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/data/slaughter.yaml
+++ b/data/slaughter.yaml
@@ -243,3 +243,24 @@ usa:
         - September: 24169000
         - October: 26380000
         - November: 23850000
+
+tragedies:
+  sources: !omap
+  - 'Yale Law School Avalon Project': 'http://avalon.law.yale.edu/20th_century/mp10.asp'
+  - '9/11 Commission Executive Summary': 'http://www.9-11commission.gov/report/911Report_Exec.pdf'
+  - 'National World War 2 Museum': 'http://www.nationalww2museum.org/learn/education/for-students/ww2-history/ww2-by-the-numbers/world-wide-deaths.html'
+  - 'University of Michigan Study': 'http://www.tandfonline.com/doi/abs/10.1080/13623699.2010.535279'
+  - 'National Hurricane Center': 'http://www.nhc.noaa.gov/data/tcr/AL122005_Katrina.pdf'
+  - 'United States Holocaust Memorial Museum': 'https://www.ushmm.org/wlc/en/media_nm.php?ModuleId=10005143&MediaId=3372'
+  hiroshima:
+    total: 66000 
+  nine_eleven:
+    total: 3000
+  wwii:
+    total: 60000000
+  haiti_earthquake:
+    total: 158679
+  hurricane_katrina:
+    total: 1833
+  holocaust:
+    total: 6000000

--- a/data/slaughter.yaml
+++ b/data/slaughter.yaml
@@ -246,21 +246,15 @@ usa:
 
 tragedies:
   sources: !omap
-  - 'Yale Law School Avalon Project': 'http://avalon.law.yale.edu/20th_century/mp10.asp'
-  - '9/11 Commission Executive Summary': 'http://www.9-11commission.gov/report/911Report_Exec.pdf'
-  - 'National World War 2 Museum': 'http://www.nationalww2museum.org/learn/education/for-students/ww2-history/ww2-by-the-numbers/world-wide-deaths.html'
-  - 'University of Michigan Study': 'http://www.tandfonline.com/doi/abs/10.1080/13623699.2010.535279'
   - 'National Hurricane Center': 'http://www.nhc.noaa.gov/data/tcr/AL122005_Katrina.pdf'
+  - '9/11 Commission Executive Summary': 'http://www.9-11commission.gov/report/911Report_Exec.pdf'
+  - 'Yale Law School Avalon Project': 'http://avalon.law.yale.edu/20th_century/mp10.asp'
+  - 'University of Michigan Study': 'http://www.tandfonline.com/doi/abs/10.1080/13623699.2010.535279'
   - 'United States Holocaust Memorial Museum': 'https://www.ushmm.org/wlc/en/media_nm.php?ModuleId=10005143&MediaId=3372'
-  hiroshima:
-    total: 66000 
-  nine_eleven:
-    total: 3000
-  wwii:
-    total: 60000000
-  haiti_earthquake:
-    total: 158679
-  hurricane_katrina:
-    total: 1833
-  holocaust:
-    total: 6000000
+  - 'National World War 2 Museum': 'http://www.nationalww2museum.org/learn/education/for-students/ww2-history/ww2-by-the-numbers/world-wide-deaths.html'
+  hurricane_katrina: 1833
+  nine_eleven: 3000
+  hiroshima: 66000 
+  haiti_earthquake: 158679
+  holocaust: 6000000
+  wwii: 60000000

--- a/source/counter/_html.erb
+++ b/source/counter/_html.erb
@@ -1,22 +1,22 @@
 <h2>Animals killed for food since opening this page</h2>
 <ul class="animal-kill-counter">
-  <li><span id="akc-wild_caught_fish">0</span> wild caught fish</li>
-  <li><span id="akc-chickens">0</span> chickens</li>
-  <li><span id="akc-farmed_fish">0</span> farmed fish</li>
-  <li><span id="akc-ducks">0</span> ducks</li>
-  <li><span id="akc-pigs">0</span> pigs</li>
-  <li><span id="akc-rabbits">0</span> rabbits</li>
-  <li><span id="akc-geese">0</span> geese</li>
-  <li><span id="akc-turkeys">0</span> turkeys</li>
-  <li><span id="akc-sheep">0</span> sheep</li>
-  <li><span id="akc-goats">0</span> goats</li>
-  <li><span id="akc-cattle">0</span> cattle</li>
-  <li><span id="akc-rodents">0</span> rodents</li>
-  <li><span id="akc-other_birds">0</span> pigeons and other birds</li>
-  <li><span id="akc-buffalo">0</span> buffalo</li>
-  <li><span id="akc-horses">0</span> horses</li>
-  <li><span id="akc-donkeys">0</span> donkeys and mules</li>
-  <li><span id="akc-camels">0</span> camels and other camelids</li>
+  <li><span id="akc-wild_caught_fish">0</span> wild caught fish <span id="akc-wild_caught_fish-milestone"></span></li>
+  <li><span id="akc-chickens">0</span> chickens <span id="akc-chickens-milestone"></span></li>
+  <li><span id="akc-farmed_fish">0</span> farmed fish <span id="akc-farmed_fish-milestone"></span></li>
+  <li><span id="akc-ducks">0</span> ducks <span id="akc-ducks-milestone"></span></li>
+  <li><span id="akc-pigs">0</span> pigs <span id="akc-pigs-milestone"></span></li>
+  <li><span id="akc-rabbits">0</span> rabbits <span id="akc-rabbits-milestone"></span></li>
+  <li><span id="akc-geese">0</span> geese <span id="akc-geese-milestone"></span></li>
+  <li><span id="akc-turkeys">0</span> turkeys <span id="akc-turkeys-milestone"></span></li>
+  <li><span id="akc-sheep">0</span> sheep <span id="akc-sheep-milestone"></span></li>
+  <li><span id="akc-goats">0</span> goats <span id="akc-goats-milestone"></span></li>
+  <li><span id="akc-cattle">0</span> cattle <span id="akc-cattle-milestone"></span></li>
+  <li><span id="akc-rodents">0</span> rodents <span id="akc-rodents-milestone"></span></li>
+  <li><span id="akc-other_birds">0</span> pigeons and other birds <span id="akc-other_birds-milestone"></span></li>
+  <li><span id="akc-buffalo">0</span> buffalo <span id="akc-buffalo-milestone"></span></li>
+  <li><span id="akc-horses">0</span> horses <span id="akc-horses-milestone"></span></li>
+  <li><span id="akc-donkeys">0</span> donkeys and mules <span id="akc-donkeys-milestone"></span></li>
+  <li><span id="akc-camels">0</span> camels and other camelids <span id="akc-camels-milestone"></span></li>
 </ul>
 
 <h3>Sources</h3>

--- a/source/counter/_javascript.erb
+++ b/source/counter/_javascript.erb
@@ -23,17 +23,41 @@ window.addEventListener('DOMContentLoaded',function(){
     "camels": <%=(data.slaughter.world.camels.total_2013+data.slaughter.world.camelids.total_2013)%>,
   };
 
+  var milestones = [
+	{title: "Hurricane Katrina", count: <%=data.slaughter.tragedies.hurricane_katrina%>},
+	{title: "9/11", count: <%=data.slaughter.tragedies.nine_eleven%>},
+	{title: "Hiroshima", count: <%=data.slaughter.tragedies.hiroshima%>},
+	{title: "Haiti", count: <%=data.slaughter.tragedies.haiti_earthquake%>},
+	{title: "Holocaust", count: <%=data.slaughter.tragedies.holocaust%>},
+	{title: "WWII", count: <%=data.slaughter.tragedies.wwii%>}
+  ];
+  var currentMilestone = [ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ];
+  var pageLoad = Date.now();
+
   var secondsPerYear = 365 * 24 * 60 * 60;
   var interval = 1000/ updatesPerSecond;
   var count = 0, start = new Date().getTime();
 
   function update(intervalCount) {
+	var i = 0;
     for (var subset in animalsKilledPerYear) {
       var numKilled = animalsKilledPerYear[subset];
       var countElement = document.getElementById("akc-" + subset);
-      if (countElement) {
-        countElement.innerHTML = Math.round(intervalCount * (numKilled/secondsPerYear) / updatesPerSecond).toLocaleString();
-      }
+	  var killCount = Math.round(intervalCount * (numKilled/secondsPerYear) / updatesPerSecond);
+	  if (countElement) {
+        countElement.innerHTML = killCount.toLocaleString();
+	  }
+      if (milestones[currentMilestone[i] + 1] != null){
+		if (killCount > milestones[currentMilestone[i] + 1].count){
+	      currentMilestone[i]++;
+	      var time = Date.now() - pageLoad;
+	      var seconds = time/1000;
+		  var milestoneElement = document.getElementById("akc-" + subset + "-milestone");
+		  if (milestoneElement)
+			  milestoneElement.innerHTML = '- equivalent of ' +  milestones[currentMilestone[i]].title + ' every ' +  seconds.toString() + ' seconds';
+		}
+	  }
+	  i++;
     }
   }
 


### PR DESCRIPTION
Several milestones such as 9/11, Hiroshima, etc... will appear next to the individual counters when they surpass the given casualty count. This is to help give a little context to numbers that can be really hard to conceptualize after a certain point.
![killcounterscreenshot](https://cloud.githubusercontent.com/assets/8453933/13896787/0249d5ee-ed70-11e5-8eb0-204a07ad6425.png)
